### PR TITLE
rubocopで推奨される記述方法にソースコードを対応させました。

### DIFF
--- a/01.fizzbuzz/fizzbuzz.rb
+++ b/01.fizzbuzz/fizzbuzz.rb
@@ -1,41 +1,16 @@
-=begin
-このプログラムを実行すると、1から20までの数をコンソール上に表示します。
-ただし、下記の条件の数は表示が変わります。
-・3の倍数は代わりにFizzを表示する
-・5の倍数は代わりにBuzzを表示する
-・3と5両方の倍数は代わりにFizzBuzzを表示する
-=end
+# frozen_string_literal: true
 
-# 整数の引数numを受け取り、表示するべき文字列を計算して返す関数get_string_to_displayを定義
+def main
+  (1..20).each do |num|
+    puts get_string_to_display(num)
+  end
+end
+
 def get_string_to_display(num)
-  # 返却する文字列を格納する変数resを用意し空文字列で初期化
-  res = ""
-  # numが3の倍数ならば文字列'Fizz'をresに合成する
-  if num % 3 == 0
-    res += "Fizz"
-  end
-  # numが5の倍数ならば文字列'Buzz'をresに合成する
-  if num % 5 == 0
-    res += "Buzz"
-  end
-  # resが空文字列ならば、numを文字列に変換してresに合成する
-  if res ==""
-    res += num.to_s
-  end
-  # resを返却する
-  return res
+  res += 'Fizz' if (num % 3).zero?
+  res += 'Buzz' if (num % 5).zero?
+  res += num.to_s if res == ''
+  res
 end
 
-# ------------------------
-# 以下、メインの処理を記述
-
-# 表示したい数の始めと終わりを指定
-first_num = 1
-last_num = 20
-
-# 下記を繰り返し処理
-for num in Range.new(first_num, last_num) do
-  # get_string_to_displayを数字ごとに呼び出しし、画面に出力
-  puts get_string_to_display(num)
-end
-# 繰り返しここまで
+main

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'rubocop', require: false
+
+# For fjord bootcamp development
+# For plain Ruby scripts
+group :development do
+  gem 'rubocop-fjord', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,46 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    parallel (1.24.0)
+    parser (3.3.1.0)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
+    rainbow (3.1.1)
+    regexp_parser (2.9.1)
+    rexml (3.2.6)
+    rubocop (1.63.5)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-fjord (0.3.0)
+      rubocop (>= 1.0)
+      rubocop-performance
+    rubocop-performance (1.21.0)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.5.0)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  rubocop
+  rubocop-fjord
+
+BUNDLED WITH
+   2.5.9


### PR DESCRIPTION
Fizzbuzz問題のソースコードをrubocop-fjord推奨の記述に対応しました。
また、rubocop-fjordの導入にあたって、必要なGemfile、Gemfile.lockを追加しました。