### PR TITLE
calenderのプログラム(Ruby)の実装

### DIFF
--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -32,7 +32,13 @@ def display_calender_of_month(month, year)
   # 日付けを出力
   Range.new(1, last_date_of_month.day).each do |day|
     date = Date.new(year, month, day)
-    printf('%2d', date.day.to_s)
+    if date == Date.today
+      print("\e[7m") # 文字色と背景色を入れ替えて表示(ANSI excape codeを使用)
+      printf('%2d', date.day.to_s)
+      print("\e[0m") # 文字色、背景色をリセット
+    else
+      printf('%2d', date.day.to_s)
+    end
     date.saturday? ? print("\n") : print("\s")
   end
   print("\n")

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'date'
+require 'optparse'
+
+def main
+  opt = OptionParser.new
+  params = {}
+  opt.on('-m, month') { |v| params[:m] = v }
+  opt.on('-y, year') { |v| params[:y] = v }
+  opt.parse!(ARGV)
+
+  month = params[:m] ? params[:m].to_i : Date.today.month
+  year = params[:y] ? params[:y].to_i : Date.today.year
+
+  display_calender_of_month(month, year)
+end
+
+def display_calender_of_month(month, year)
+  first_date_of_month = Date.new(year, month, 1)
+  last_date_of_month = Date.new(year, month, -1)
+
+  # 月の初日を表示する位置のインデント量を、その曜日に応じて計算
+  indent_length = 3 * first_date_of_month.wday # wdayメソッドの返リ値は0-6 (日曜日が0)
+
+  # カレンダーのヘッダを出力
+  puts("#{first_date_of_month.strftime('%B')} #{year}".center(20))
+  puts('Su Mo Tu We Th Fr Sa')
+  print(''.rjust(indent_length))
+
+  # 日付けを出力
+  Range.new(1, last_date_of_month.day).each do |day|
+    date = Date.new(year, month, day)
+    printf('%2d', date.day.to_s)
+    date.saturday? ? print("\n") : print("\s")
+  end
+  print("\n")
+end
+
+main

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -17,17 +17,17 @@ def main
   display_calender_of_month(month, year)
 end
 
+INDENT_LENGTH_OF_DAY = 3
+CALENDAR_WIDTH = 20
+
 def display_calender_of_month(month, year)
   first_date_of_month = Date.new(year, month, 1)
   last_date_of_month = Date.new(year, month, -1)
 
-  # 月の初日を表示する位置のインデント量を、その曜日に応じて計算
-  indent_length = 3 * first_date_of_month.wday # wdayメソッドの返リ値は0-6 (日曜日が0)
-
   # カレンダーのヘッダを出力
-  puts("#{first_date_of_month.strftime('%B')} #{year}".center(20))
+  puts("#{first_date_of_month.strftime('%B')} #{year}".center(CALENDAR_WIDTH))
   puts('Su Mo Tu We Th Fr Sa')
-  print(''.rjust(indent_length))
+  print(' ' * INDENT_LENGTH_OF_DAY * first_date_of_month.wday)
 
   # 日付けを出力
   Range.new(1, last_date_of_month.day).each do |day|

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -39,7 +39,7 @@ def display_calender_of_month(month, year)
     else
       printf('%2d', date.day.to_s)
     end
-    date.saturday? ? print("\n") : print("\s")
+    date.saturday? ? print("\n") : print(' ')
   end
   print("\n")
 end


### PR DESCRIPTION
## 実施課題

[[プラクティス カレンダーのプログラム\(Ruby\) \| FBC](https://bootcamp.fjord.jp/practices/194)](https://bootcamp.fjord.jp/practices/194)

## 実施タスク

02.calendar/cal.rbを追加しました。

## レビューしていただきたい項目

下記の仕様通りにコンソール上に表示が行われること。

### 必須要件リスト

- ruby-practice/02.calendarのディレクトリに移動し、`./cal.rb`で実行できる
- mで月を、-yで年を指定できる　（少なくとも1970年から2100年までは正しく表示される）
- 引数を指定しない場合は、今月・今年のカレンダーが表示される
- MacやWSLに入っているcalコマンドと同じ見た目になっている

※　補足事項
自分の実行環境のcalコマンドでは、-yを指定すると-mオプションを指定していても１年分のカレンダーが表示される実装となっていました。今回実装したプログラムでは、課題の必須要件を優先して、特定の月だけを表示するようにしています。

### 実装した歓迎要件リスト

- 今日の日付の部分の色が反転する(背景色と文字色が入れ替わる)

## セルフチェックで用いた実行環境

```
❯ ruby --version
ruby 3.3.1 (2024-04-23 revision c56cd86388) [x86_64-linux]

❯ apt list --installed | grep ncal
ncal/stable,now 12.1.8 amd64 [installed]

```

## 備考
rubocopの導入が済んでいるため、rubocopをパスすることも確認しました。

以上、レビュー宜しくお願いいたします！