### PR TITLE
lオプション付きのlsコマンドの実装

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -92,13 +92,13 @@ def convert_filemode_to_display_format(filemode)
   filemode_octal = format('%06<number>d', number: filemode.to_s(8))
   filemode_str = FILETYPE[filemode_octal.slice(0..1)] + (3..5).map { |i| PERMISSION[filemode_octal.slice(i)] }.join
   special_permission = format('%03<number>d', number: filemode_octal.slice(2).to_i(2))
-  if special_permission.slice(0) == 1
+  if special_permission.slice(0) == '1'
     filemode_str[3] = filemode_str[3] == 'x' ? 's' : 'S'
   end
-  if special_permission.slice(1) == 1
+  if special_permission.slice(1) == '1'
     filemode_str[6] = filemode_str[6] == 'x' ? 's' : 'S'
   end
-  if special_permission.slice(2) == 1
+  if special_permission.slice(2) == '1'
     filemode_str[9] = filemode_str[9] == 'x' ? 't' : 'T'
   end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -140,7 +140,6 @@ def display_file_status(filenames, dir_path = '.')
   return if filenames.empty?
 
   file_status_list = filenames.map { |filename| file_status(filename, dir_path) }
-
   file_status_list.each do |file_status|
     output = file_status.map do |key, value|
       max_width = file_status_list.map { |v| v[key].size }.max

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -9,8 +9,28 @@ MAX_NUM_OF_COLUMNS = 3
 WINDOW_WIDTH = `tput cols`.chomp.to_i
 BLOCK_SIZE_RATIO = 2
 
+FILETYPE = {
+  '01' => 'p',
+  '02' => 'c',
+  '04' => 'd',
+  '06' => 'b',
+  '10' => '-',
+  '12' => 'l',
+  '14' => 's'
+}.freeze
+PERMISSION = {
+  '0' => '---',
+  '1' => '--x',
+  '2' => '-w-',
+  '3' => '-wx',
+  '4' => 'r--',
+  '5' => 'r-x',
+  '6' => 'rw-',
+  '7' => 'rwx'
+}.freeze
+
 def main
-  flags = { filename_pattern: 0, reverse: false, long_format: false}
+  flags = { filename_pattern: 0, reverse: false, long_format: false }
   opt = OptionParser.new
   opt.on('-a') { flags[:filename_pattern] = File::FNM_DOTMATCH }
   opt.on('-r') { flags[:reverse] = true }
@@ -18,22 +38,13 @@ def main
   opt.parse!(ARGV)
 
   filename_paths, dir_paths = valid_input_paths
-  if flags[:long_format]
-    display_file_status(filename_paths)
-  else
-    display_filenames(filename_paths)
-  end
+  display_filenames(filename_paths, flags[:long_format])
   puts if !filename_paths.empty? && !dir_paths.empty?
   dir_paths.each_with_index do |dir_path, index|
-    fs = File::Stat.new(File.expand_path(dir_path))
     puts "#{dir_path}:" if ARGV.size > 1
     filenames = Dir.glob('*', flags[:filename_pattern], base: dir_path)
     sorted_filenames = sort_for_display(filenames, flags[:reverse])
-    if flags[:long_format]
-      display_file_status(sorted_filenames)
-    else
-      display_filenames(sorted_filenames)
-    end
+    display_filenames(sorted_filenames, flags[:long_format])
     puts unless index == dir_paths.size - 1
   end
 end
@@ -68,25 +79,47 @@ def create_matrix_for_display(filenames, num_of_columns)
   end.transpose
 end
 
+def convert_to_display_format(filemode)
+  filemode_octal = format('%06<number>d', number: filemode.to_s(8))
+  filemode_str = FILETYPE[filemode_octal.slice(0..1)] + (3..5).map { |i| PERMISSION[filemode_octal.slice(i)] }.join
+  special_permission = format('%03<number>d', number: filemode_octal.slice(2).to_i(2))
+  if special_permission.slice(0) == 1
+    filemode_str[3] = filemode_str[3] == 'x' ? 's' : 'S'
+  end
+  if special_permission.slice(1) == 1
+    filemode_str[6] = filemode_str[6] == 'x' ? 's' : 'S'
+  end
+  if special_permission.slice(2) == 1
+    filemode_str[9] = filemode_str[9] == 'x' ? 't' : 'T'
+  end
+
+  filemode_str
+end
+
 def display_file_status(filenames)
   return if filenames.empty?
 
   block_counts = filenames.map do |filename|
     File.lstat(File.expand_path(filename)).blocks
   end.sum
-  puts "total #{ block_counts / BLOCK_SIZE_RATIO }"
+  puts "total #{block_counts / BLOCK_SIZE_RATIO}"
 
   filenames.each do |filename|
     fs = File.lstat(File.expand_path(filename))
     owner_name = Etc.getpwuid(fs.uid).name
     group_name = Etc.getgrgid(fs.gid).name
-    printf "%o ", fs.mode
-    puts "#{fs.nlink} #{owner_name} #{group_name} #{fs.size} #{fs.mtime} #{filename}"
+    filemode = convert_to_display_format(fs.mode)
+    puts "#{filemode} #{fs.nlink} #{owner_name} #{group_name} #{fs.size} #{fs.mtime} #{filename}"
   end
 end
 
-def display_filenames(filenames)
+def display_filenames(filenames, long_format_flag)
   return if filenames.empty?
+
+  if long_format_flag
+    display_file_status(filenames)
+    return
+  end
 
   num_of_columns = 1
   # ウインドウの幅におさまる範囲で表示列数を最大にする

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -109,7 +109,13 @@ def display_file_status(filenames)
     owner_name = Etc.getpwuid(fs.uid).name
     group_name = Etc.getgrgid(fs.gid).name
     filemode = convert_to_display_format(fs.mode)
-    puts "#{filemode} #{fs.nlink} #{owner_name} #{group_name} #{fs.size} #{fs.mtime} #{filename}"
+    timestamp = fs.mtime.strftime('%b %e ')
+    if fs.mtime.year == Time.now.year
+      timestamp += fs.mtime.strftime('%R')
+    else
+      timestamp += fs.mtime.strftime('%Y')
+    end
+    puts "#{filemode} #{fs.nlink} #{owner_name} #{group_name} #{fs.size} #{timestamp} #{filename}"
   end
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -7,7 +7,7 @@ require 'etc'
 INDENT_SIZE = 2
 MAX_NUM_OF_COLUMNS = 3
 WINDOW_WIDTH = `tput cols`.chomp.to_i
-BLOCK_SIZE_RATIO = 2
+BLOCK_SIZE_RATIO = 2 # Rubyとos標準lsコマンド間のブロックサイズの基準の違いを補正する比率
 
 FILE_TYPES = {
   1 => 'p',

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -137,7 +137,11 @@ def file_status(filename, dir_path = '.')
   nlink = fs.nlink.to_s
   owner_name = Etc.getpwuid(fs.uid).name
   group_name = Etc.getgrgid(fs.gid).name
-  filesize = fs.size.to_s
+  filesize = if filemode.start_with?('b', 'c')
+               [fs.rdev_major, fs.rdev_minor].join(', ')
+             else
+               fs.size.to_s
+             end
   timestamp = convert_timestamp_to_display_format(fs.mtime)
   filename += " -> #{File.readlink(file_path)}" if File.symlink?(file_path)
   { filemode:, nlink:, owner_name:, group_name:, filesize:, timestamp:, filename: }

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -98,7 +98,7 @@ def display_total_blocks(filenames, dir_path = '.')
   puts "total #{block_counts / BLOCK_SIZE_RATIO}"
 end
 
-def convert_filemode_to_display_format(filemode)
+def decode_filemode_to_string(filemode)
   filemode_octal = format('%06<number>d', number: filemode.to_s(8))
   filemode_str = FILETYPE[filemode_octal.slice(0..1)] + (3..5).map { |i| PERMISSION[filemode_octal.slice(i)] }.join
   special_permission = format('%03<number>d', number: filemode_octal.slice(2).to_i(2))
@@ -129,7 +129,7 @@ def file_status_list(filenames, dir_path = '.')
     fs = File.lstat(file_path)
     owner_name = Etc.getpwuid(fs.uid).name
     group_name = Etc.getgrgid(fs.gid).name
-    filemode = convert_filemode_to_display_format(fs.mode)
+    filemode = decode_filemode_to_string(fs.mode)
     timestamp = convert_timestamp_to_display_format(fs.mtime)
     filename += " -> #{File.readlink(file_path)}" if File.symlink?(file_path)
     [filemode, fs.nlink.to_s, owner_name, group_name, fs.size.to_s, timestamp, filename]

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -18,6 +18,7 @@ FILE_TYPES = {
   12 => 'l',
   14 => 's'
 }.freeze
+
 PERMISSION_TYPES = {
   0 => '---',
   1 => '--x',
@@ -28,6 +29,7 @@ PERMISSION_TYPES = {
   6 => 'rw-',
   7 => 'rwx'
 }.freeze
+
 AUTHORITY_LEVELS = {
   0 => { name: 'owner', special_permission: { name: 'SUID', letter: 's' } },
   1 => { name: 'group', special_permission: { name: 'SGID', letter: 's' } },

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -153,12 +153,14 @@ def display_file_status(filenames, dir_path = '.')
   return if filenames.empty?
 
   file_status_list = filenames.map { |filename| file_status(filename, dir_path) }
+  max_width = file_status_list[0].keys.map do |key|
+    [key, file_status_list.map { |v| v[key].size }.max]
+  end.to_h
   file_status_list.each do |file_status|
     output = file_status.map do |key, value|
-      max_width = file_status_list.map { |v| v[key].size }.max
       case key
-      when :nlink, :filesize then value.rjust(max_width)
-      when :owner_name, :group_name, :filename then value.ljust(max_width)
+      when :nlink, :filesize then value.rjust(max_width[key])
+      when :owner_name, :group_name, :filename then value.ljust(max_width[key])
       else value
       end
     end.join(' ')


### PR DESCRIPTION
## 実施課題
[プラクティス lsコマンドを作る4 \| FBC](https://bootcamp.fjord.jp/practices/224)

## 実施タスク
04.ls/ls.rbを修正しました。

## レビューしていただきたい項目
- 04.ls/ls.rb を-lオプションで実行し、[Docs: lsコマンドを作る \| FBC](https://bootcamp.fjord.jp/pages/ls-command#requirements)の要件の通りにコンソール上に表示が行われること。

## セルフチェックで用いた実行環境
OS:  Debian GNU/Linux 12 (bookworm)
Ruby version:  3.3.1 (2024-04-23 revision c56cd86388) [x86_64-linux]
Shell:  zsh 5.9 (x86_64-debian-linux-gnu)

以上、レビュー宜しくお願いいたします！